### PR TITLE
Stage in from hrefs

### DIFF
--- a/app_pack_generator/templates/stage_in.cwl
+++ b/app_pack_generator/templates/stage_in.cwl
@@ -23,7 +23,9 @@ inputs:
     default: '/sps/processing/workflows/edl_username'
     type: string
   stac_json:
-    type: string 
+    type: 
+    - string
+    - File 
 
 # DAPA auth
   unity_username:
@@ -58,6 +60,7 @@ outputs:
       glob: .
     type: Directory
 requirements:
+  InlineJavascriptRequirement
   DockerRequirement:
     dockerPull: ghcr.io/unity-sds/unity-data-services:6.4.3
   EnvVarRequirement:
@@ -76,7 +79,15 @@ requirements:
       OUTPUT_FILE: $(runtime.outdir)/stage-in-results.json
       PARALLEL_COUNT: '-1'
       #what if this is a string?
-      STAC_JSON: $(inputs.stac_json) 
+      STAC_JSON: |
+      ${
+        if (inputs.stac_json == Object){
+          return inputs.stac_json.path; 
+        }
+        else{
+          return inputs.stac_json;
+        }
+      } #$(inputs.stac_json) 
 
       USERNAME: $(inputs.unity_username)
       PASSWORD: $(inputs.unity_password)

--- a/app_pack_generator/templates/stage_in.cwl
+++ b/app_pack_generator/templates/stage_in.cwl
@@ -4,6 +4,7 @@ baseCommand:
 class: CommandLineTool
 cwlVersion: v1.2
 inputs:
+  # S3 or DAAC or HTTP
   download_type:
     type: string
   downloading_keys:
@@ -14,13 +15,39 @@ inputs:
     type: string
   edl_password:
     type: string
+    default: '/sps/processing/workflows/edl_password'
   edl_password_type:
-    default: BASE64
+    default: 'PARAM_STORE'
     type: string
   edl_username:
+    default: '/sps/processing/workflows/edl_username'
     type: string
   stac_json:
-    type: File
+    type: string 
+
+# DAPA auth
+  unity_username:
+    default: '/sps/processing/workflows/unity_username'
+    type: string
+  unity_password:
+    default: '/sps/processing/workflows/unity_password'
+    type: string
+  unity_type: 
+    default: 'PARAM_STORE'
+    type: string
+  unity_client_id: 
+    type: string
+  unity_cognito: 
+    type: string
+    default: 'https://cognito-idp.us-west-2.amazonaws.com'
+  unity_ssl:
+    type: string
+    default: 'TRUE'
+  # NONE or UNITY
+  unity_stac_auth:
+    type: string
+    default: 'NONE'
+     
 outputs:
   stage_in_collection_file:
     outputBinding:
@@ -48,4 +75,16 @@ requirements:
       LOG_LEVEL: '20'
       OUTPUT_FILE: $(runtime.outdir)/stage-in-results.json
       PARALLEL_COUNT: '-1'
-      STAC_JSON: $(inputs.stac_json.path)
+      #what if this is a string?
+      STAC_JSON: $(inputs.stac_json) 
+
+      USERNAME: $(inputs.unity_username)
+      PASSWORD: $(inputs.unity_password)
+      PASSWORD_TYPE: $(inputs.unity_type)
+      CLIENT_ID: $(inputs.unity_client_id)
+      COGNITO_URL: $(inputs.unity_cognito)
+      VERIFY_SSL: $(inputs.unity_ssl)
+      
+      #'UNITY | NONE'
+      STAC_AUTH_TYPE: $(inputs.unity_stac_auth)
+      

--- a/app_pack_generator/templates/stage_in.cwl
+++ b/app_pack_generator/templates/stage_in.cwl
@@ -60,42 +60,51 @@ outputs:
       glob: .
     type: Directory
 requirements:
-  InlineJavascriptRequirement
+  InlineJavascriptRequirement: {}
   DockerRequirement:
     dockerPull: ghcr.io/unity-sds/unity-data-services:6.4.3
   EnvVarRequirement:
-    envDef:
-      DOWNLOADING_KEYS: $(inputs.downloading_keys)
-      DOWNLOADING_ROLES: $(inputs.downloading_roles)
-      DOWNLOAD_DIR: $(runtime.outdir)
-      DOWNLOAD_RETRY_TIMES: '5'
-      DOWNLOAD_RETRY_WAIT_TIME: '30'
-      EDL_BASE_URL: https://urs.earthdata.nasa.gov/
-      EDL_PASSWORD: $(inputs.edl_password)
-      EDL_PASSWORD_TYPE: $(inputs.edl_password_type)
-      EDL_USERNAME: $(inputs.edl_username)
-      GRANULES_DOWNLOAD_TYPE: $(inputs.download_type)
-      LOG_LEVEL: '20'
-      OUTPUT_FILE: $(runtime.outdir)/stage-in-results.json
-      PARALLEL_COUNT: '-1'
-      #what if this is a string?
-      STAC_JSON: |
-      ${
-        if (inputs.stac_json == Object){
-          return inputs.stac_json.path; 
-        }
-        else{
-          return inputs.stac_json;
-        }
-      } #$(inputs.stac_json) 
-
-      USERNAME: $(inputs.unity_username)
-      PASSWORD: $(inputs.unity_password)
-      PASSWORD_TYPE: $(inputs.unity_type)
-      CLIENT_ID: $(inputs.unity_client_id)
-      COGNITO_URL: $(inputs.unity_cognito)
-      VERIFY_SSL: $(inputs.unity_ssl)
-      
-      #'UNITY | NONE'
-      STAC_AUTH_TYPE: $(inputs.unity_stac_auth)
-      
+    envDef: 
+      -  envName: CLIENT_ID
+         envValue: $(inputs.unity_client_id)
+      -  envName: COGNITO_URL 
+         envValue: $(inputs.unity_cognito)
+      -  envName: DOWNLOADING_KEYS
+         envValue: $(inputs.downloading_keys)
+      -  envName: DOWNLOADING_ROLES
+         envValue: $(inputs.downloading_roles)
+      -  envName: DOWNLOAD_DIR
+         envValue: $(runtime.outdir)
+      -  envName: DOWNLOAD_RETRY_TIMES
+         envValue: '5'
+      -  envName: DOWNLOAD_RETRY_WAIT_TIME
+         envValue: '30'
+      -  envName: EDL_BASE_URL
+         envValue: https://urs.earthdata.nasa.gov/
+      -  envName: EDL_PASSWORD
+         envValue: $(inputs.edl_password)
+      -  envName: EDL_PASSWORD_TYPE
+         envValue: $(inputs.edl_password_type)
+      -  envName: EDL_USERNAME
+         envValue: $(inputs.edl_username)
+      -  envName: GRANULES_DOWNLOAD_TYPE
+         envValue: $(inputs.download_type)
+      -  envName: LOG_LEVEL
+         envValue: '20'
+      -  envName: OUTPUT_FILE
+         envValue: $(runtime.outdir)/stage-in-results.json
+      -  envName: PARALLEL_COUNT
+         envValue: '-1'
+      -  envName: PASSWORD
+         envValue: $(inputs.unity_password)
+      -  envName: PASSWORD_TYPE
+         envValue: $(inputs.unity_type)
+      -  envName: STAC_AUTH_TYPE
+         envValue: $(inputs.unity_stac_auth)
+      -  envName: USERNAME
+         envValue: $(inputs.unity_username)
+      -  envName: VERIFY_SSL
+         envValue: $(inputs.unity_ssl)
+      -  envName: STAC_JSON
+         envValue: "${\n console.log(typeof inputs.stac_json);\n if (typeof inputs.stac_json === 'object'){\n    return inputs.stac_json.path;\n\
+        \  }\n  else{\n    return inputs.stac_json;\n  }\n}\n"

--- a/app_pack_generator/templates/stage_out.cwl
+++ b/app_pack_generator/templates/stage_out.cwl
@@ -52,8 +52,8 @@ requirements:
       STAGING_BUCKET: $(inputs.staging_bucket)
       CATALOG_FILE: '$(inputs.output_dir.path)/catalog.json'
       OUTPUT_FILE: '$(runtime.outdir)/stage-out-results.json'
-      LOG_LEVEL: '10'
-      PARALLEL_COUNT: '2'
+      LOG_LEVEL: '20'
+      PARALLEL_COUNT: '-1'
       OUTPUT_DIRECTORY: $(runtime.outdir)
       
   InitialWorkDirRequirement:

--- a/app_pack_generator/templates/workflow.cwl
+++ b/app_pack_generator/templates/workflow.cwl
@@ -21,14 +21,15 @@ inputs:
     type:
       type: record
       fields:
-        stac_json: File
+        stac_json: string 
         download_type: string # DAAC or S3
         edl_username: [ string, 'null' ]
         edl_password: [ string, 'null' ]
         edl_password_type: [ string, 'null' ]
         downloading_keys: [ string, 'null' ]
         downloading_roles: [ string, 'null' ]
-
+        unity_client_id: string
+        unity_stac_auth: string # UNITY or NONE
       
   ###########
   # Stage Out
@@ -86,7 +87,12 @@ steps:
       downloading_roles:
         source: stage_in
         valueFrom: $(self.downloading_roles)
-
+      unity_client_id:
+        source: stage_in
+        valueFrom: $(self.unity_client_id)
+      unity_stac_auth:
+        source: stage_in
+        valueFrom: $(self.unity_stac_auth)
 
     out: [stage_in_collection_file, stage_in_download_dir]
 

--- a/app_pack_generator/templates/workflow.cwl
+++ b/app_pack_generator/templates/workflow.cwl
@@ -21,7 +21,7 @@ inputs:
     type:
       type: record
       fields:
-        stac_json: string 
+        stac_json: [string, File]
         download_type: string # DAAC or S3
         edl_username: [ string, 'null' ]
         edl_password: [ string, 'null' ]


### PR DESCRIPTION
A lot of work done here to make life easier.

1. Restructured some default values in stage-in and stage-out to make reasonable assumptions (e.g. param names)
2. Allow for 'string' or 'file' type of stage-in- created a lot of work in being able to parse a dict-object (file) within the stage-in code. 
3. Above change allows a user to add a url to a stac file, not pass a stac file directly. This allows us to run application packages against unity or cmr files directly.
4. to enable the in-line javascript in stage-in, i had to restructure how the environment variables are set (envdef - envname, envvalue).
5. Changed default log level of stage-out to be 'info' - in the future this should default to info and be overridden if we choose to.

Tested by creating a number of app packages (preprocess, resample, and others).