### PR TITLE
#26 - Update process.cwl to output and return papermill standard output

### DIFF
--- a/app_pack_generator/templates/process.cwl
+++ b/app_pack_generator/templates/process.cwl
@@ -9,6 +9,7 @@ baseCommand:
   - process_output/output_nb.ipynb
   - -f
   - /tmp/inputs.json
+  - --log-output
 requirements:
   DockerRequirement:
     dockerPull: marjoluc/hello-world:stable
@@ -35,4 +36,3 @@ outputs:
     outputBinding:
       glob: "$(runtime.outdir)/process_output/output_nb.ipynb"
     type: File
-stdout: stdout.txt


### PR DESCRIPTION
Adds output from the jupyternotebook to the 'console' so that it can be displayed by airflow executions.

Closes #26 